### PR TITLE
fix: cache toggle api

### DIFF
--- a/includes/Api/Fastcgi_Cache.php
+++ b/includes/Api/Fastcgi_Cache.php
@@ -8,7 +8,7 @@ class Fastcgi_Cache {
      * API constructor.
      */
     public function __construct() {
-        flywp()->router->get( 'fastcgi-cache', [ $this, 'handle_cache_setting' ] );
+        flywp()->router->post( 'fastcgi-cache', [ $this, 'handle_cache_setting' ] );
     }
 
     /**
@@ -17,19 +17,18 @@ class Fastcgi_Cache {
      * @return void
      */
     public function handle_cache_setting( $args ) {
-        if ( ! isset( $args['cache'] ) ) {
+        if ( ! isset( $args['status'] ) ) {
             wp_send_json_error(
                 [
-					'message' => 'Missing cache.',
+					'message' => 'Missing status.',
 				]
             );
         }
 
-        $valid_types = [ 'fastcgi', 'none' ];
-        $cache       = isset( $args['cache'] ) && in_array( $args['cache'], $valid_types, true ) ? $args['cache'] : 'none';
+        $enabled = isset( $args['status'] ) && $args['status'] === 'enabled' ? true : false;
 
         $settings            = flywp()->fastcgi->settings();
-        $settings['enabled'] = $cache === 'fastcgi' ? true : false;
+        $settings['enabled'] = $enabled;
 
         update_option( flywp()->fastcgi::SETTINGS_KEY, $settings );
 

--- a/includes/Api/Fastcgi_Cache.php
+++ b/includes/Api/Fastcgi_Cache.php
@@ -26,7 +26,7 @@ class Fastcgi_Cache {
         }
 
         $valid_types = [ 'fastcgi', 'none' ];
-        $cache       = isset( $args['cache'] ) && in_array( $args['cache'], $valid_types ) ? $args['cache'] : 'none';
+        $cache       = isset( $args['cache'] ) && in_array( $args['cache'], $valid_types, true ) ? $args['cache'] : 'none';
 
         $settings            = flywp()->fastcgi->settings();
         $settings['enabled'] = $cache === 'fastcgi' ? true : false;

--- a/includes/Api/Fastcgi_Cache.php
+++ b/includes/Api/Fastcgi_Cache.php
@@ -8,7 +8,7 @@ class Fastcgi_Cache {
      * API constructor.
      */
     public function __construct() {
-        flywp()->router->get( 'fastcgi-cache', [$this, 'handle_cache_setting'] );
+        flywp()->router->get( 'fastcgi-cache', [ $this, 'handle_cache_setting' ] );
     }
 
     /**
@@ -17,13 +17,15 @@ class Fastcgi_Cache {
      * @return void
      */
     public function handle_cache_setting( $args ) {
-        if ( !isset( $args['cache'] ) ) {
-            wp_send_json_error( [
-                'message' => 'Missing cache.',
-            ] );
+        if ( ! isset( $args['cache'] ) ) {
+            wp_send_json_error(
+                [
+					'message' => 'Missing cache.',
+				]
+            );
         }
 
-        $valid_types = ['fastcgi', 'none'];
+        $valid_types = [ 'fastcgi', 'none' ];
         $cache       = isset( $args['cache'] ) && in_array( $args['cache'], $valid_types ) ? $args['cache'] : 'none';
 
         $settings            = flywp()->fastcgi->settings();
@@ -31,8 +33,10 @@ class Fastcgi_Cache {
 
         update_option( flywp()->fastcgi::SETTINGS_KEY, $settings );
 
-        wp_send_json_success( [
-            'message' => 'Updated successfully.',
-        ] );
+        wp_send_json_success(
+            [
+				'message' => 'Updated successfully.',
+			]
+        );
     }
 }

--- a/includes/Api/Fastcgi_Cache.php
+++ b/includes/Api/Fastcgi_Cache.php
@@ -8,7 +8,7 @@ class Fastcgi_Cache {
      * API constructor.
      */
     public function __construct() {
-        flywp()->router->post( 'fastcgi-cache', [$this, 'handle_cache_setting'] );
+        flywp()->router->get( 'fastcgi-cache', [$this, 'handle_cache_setting'] );
     }
 
     /**
@@ -17,17 +17,17 @@ class Fastcgi_Cache {
      * @return void
      */
     public function handle_cache_setting( $args ) {
-        if ( !isset( $args['status'] ) ) {
+        if ( !isset( $args['cache'] ) ) {
             wp_send_json_error( [
-                'message' => 'Missing status.',
+                'message' => 'Missing cache.',
             ] );
         }
 
-        $valid_types = ['enable', 'disable'];
-        $type        = isset( $_GET['type'] ) && in_array( $_GET['type'], $valid_types ) ? $_GET['type'] : 'enable';
+        $valid_types = ['fastcgi', 'none'];
+        $cache       = isset( $args['cache'] ) && in_array( $args['cache'], $valid_types ) ? $args['cache'] : 'none';
 
         $settings            = flywp()->fastcgi->settings();
-        $settings['enabled'] = $type === 'enable' ? true : false;
+        $settings['enabled'] = $cache === 'fastcgi' ? true : false;
 
         update_option( flywp()->fastcgi::SETTINGS_KEY, $settings );
 


### PR DESCRIPTION
This update ensures that changes made in FlyWP's Page Caching settings now correctly show up in the WordPress admin panel. The PR addresses the issue with the cache toggle API triggered from the FlyWP application.

Ref: https://github.com/flywp/flywp-app/issues/144