### PR TITLE
fix: add null value check

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -120,7 +120,7 @@ class Admin {
         $transient_key = 'flywp_site_info';
         $site_info     = get_transient( $transient_key );
 
-        if ( false === $site_info ) {
+        if ( ! $site_info ) {
             $site_info = flywp()->flyapi->site_info();
 
             if ( isset( $site_info['error'] ) ) {
@@ -141,7 +141,7 @@ class Admin {
      * @return string
      */
     private function get_site_url( $info ) {
-        if ( false === $info ) {
+        if ( ! $info ) {
             return 'https://app.flywp.com';
         }
 


### PR DESCRIPTION
Recently, we faced an issue: “Cannot access offset of type string on string” due to improper handling of null value checks.

```
[14-Mar-2025 23:28:58 UTC] PHP Fatal error:  Uncaught TypeError: Cannot access offset of type string on string in /var/www/html/public/wp-content/plugins/flywp/includes/Admin.php:150
Stack trace:
#0 /var/www/html/public/wp-content/plugins/flywp/includes/Admin.php(109): FlyWP\Admin->get_site_url('')
#1 /var/www/html/public/wp-includes/class-wp-hook.php(324): FlyWP\Admin->render_admin_page('')
#2 /var/www/html/public/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#3 /var/www/html/public/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#4 /var/www/html/public/wp-admin/admin.php(259): do_action('dashboard_page_...')
#5 /var/www/html/public/wp-admin/index.php(10): require_once('/var/www/html/p...')
#6 {main}
  thrown in /var/www/html/public/wp-content/plugins/flywp/includes/Admin.php on line 150
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the system’s handling of site data to better account for missing or incomplete information, ensuring more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->