### PR TITLE
fix: plugin deactivation error

### DIFF
--- a/flywp.php
+++ b/flywp.php
@@ -91,7 +91,9 @@ final class FlyWP_Plugin {
      * @return void
      */
     public function deactivate() {
-        ( new FlyWP\Api\UpdatesData() )->deactivate();
+        if ( $timestamp = wp_next_scheduled( FlyWP\Api\UpdatesData::CRON_HOOK ) ) {
+            wp_unschedule_event( $timestamp, FlyWP\Api\UpdatesData::CRON_HOOK );
+        }
     }
 
     /**

--- a/flywp.php
+++ b/flywp.php
@@ -91,7 +91,9 @@ final class FlyWP_Plugin {
      * @return void
      */
     public function deactivate() {
-        if ( $timestamp = wp_next_scheduled( FlyWP\Api\UpdatesData::CRON_HOOK ) ) {
+        $timestamp = wp_next_scheduled( FlyWP\Api\UpdatesData::CRON_HOOK );
+    
+        if ( $timestamp ) {
             wp_unschedule_event( $timestamp, FlyWP\Api\UpdatesData::CRON_HOOK );
         }
     }

--- a/flywp.php
+++ b/flywp.php
@@ -86,7 +86,7 @@ final class FlyWP_Plugin {
     }
 
     /**
-     * Plugin activation hook.
+     * Plugin deactivation hook.
      *
      * @return void
      */

--- a/flywp.php
+++ b/flywp.php
@@ -92,7 +92,6 @@ final class FlyWP_Plugin {
      */
     public function deactivate() {
         $timestamp = wp_next_scheduled( FlyWP\Api\UpdatesData::CRON_HOOK );
-    
         if ( $timestamp ) {
             wp_unschedule_event( $timestamp, FlyWP\Api\UpdatesData::CRON_HOOK );
         }

--- a/includes/Api/UpdatesData.php
+++ b/includes/Api/UpdatesData.php
@@ -2,11 +2,9 @@
 
 namespace FlyWP\Api;
 
-use WP_Error;
-
 class UpdatesData {
-    private const CRON_HOOK = 'flywp_send_updates_data';
-    private const CRON_INTERVAL = 'twicedaily';
+    public const CRON_HOOK = 'flywp_send_updates_data';
+    public const CRON_INTERVAL = 'twicedaily';
 
     /**
      * UpdatesData constructor.
@@ -234,16 +232,6 @@ class UpdatesData {
         }
         if ( ! function_exists( 'get_plugin_updates' ) ) {
             require_once ABSPATH . 'wp-admin/includes/update.php';
-        }
-    }
-
-    /**
-     * Deactivate the scheduler when the plugin is deactivated.
-     */
-    public function deactivate(): void {
-        $timestamp = wp_next_scheduled( self::CRON_HOOK );
-        if ( $timestamp ) {
-            wp_unschedule_event( $timestamp, self::CRON_HOOK );
         }
     }
 }


### PR DESCRIPTION
Previously, the deactivation hooks were dependent on `FlyWP\Api\UpdatesData`, which had an internal dependency on route initialization that caused an error.

This PR simplifies the plugin deactivation hooks and removes the dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved handling of scheduled background tasks during plugin deactivation for better reliability.
- **Chores**
	- Updated internal constants to be more accessible for future enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->