### PR TITLE
fix(cache purge): ensure cache URL path ends with a trailing slash

### DIFF
--- a/includes/Fastcgi_Cache.php
+++ b/includes/Fastcgi_Cache.php
@@ -120,6 +120,11 @@ class Fastcgi_Cache {
     public function purge_cache_by_url( $url ) {
         $parsed = wp_parse_url( $url );
         $path   = isset( $parsed['path'] ) ? $parsed['path'] : '';
+        
+        // Ensure path ends with trailing slash
+        if (substr($path, -1) !== '/') {
+            $path .= '/';
+        }
 
         // cache key format (without space): $protocal $method $host $path
         // because of nginx-proxy, all request will be http, so we don't need to check protocal

--- a/includes/Fastcgi_Cache.php
+++ b/includes/Fastcgi_Cache.php
@@ -120,9 +120,9 @@ class Fastcgi_Cache {
     public function purge_cache_by_url( $url ) {
         $parsed = wp_parse_url( $url );
         $path   = isset( $parsed['path'] ) ? $parsed['path'] : '';
-        
+
         // Ensure path ends with trailing slash
-        if (substr($path, -1) !== '/') {
+        if ( substr( $path, -1 ) !== '/' ) {
             $path .= '/';
         }
 


### PR DESCRIPTION
Fixes https://github.com/flywp/flywp-app/issues/1031

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache purging reliability by ensuring URL paths are consistently formatted with a trailing slash, resulting in more accurate cache management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->