### PR TITLE
fix: resolve SMTP Configuration link 404 on API fallback

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -128,6 +128,13 @@ class Admin {
             }
 
             set_transient( $transient_key, $site_info, DAY_IN_SECONDS );
+
+            // Persist site_id as a durable option so site-specific URLs
+            // remain correct even when the transient expires or the API
+            // is temporarily unreachable.
+            if ( ! empty( $site_info['id'] ) ) {
+                update_option( 'flywp_site_id', (int) $site_info['id'], false );
+            }
         }
 
         return $site_info;
@@ -141,13 +148,12 @@ class Admin {
      * @return string
      */
     private function get_site_url( $info ) {
-        if ( ! $info ) {
+        $site_id = ! empty( $info['id'] ) ? (int) $info['id'] : (int) get_option( 'flywp_site_id', 0 );
+
+        if ( ! $site_id ) {
             return 'https://app.flywp.com';
         }
 
-        return sprintf(
-            'https://app.flywp.com/site/%d',
-            $info['id']
-        );
+        return sprintf( 'https://app.flywp.com/site/%d', $site_id );
     }
 }

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -129,9 +129,7 @@ class Admin {
 
             set_transient( $transient_key, $site_info, DAY_IN_SECONDS );
 
-            // Persist site_id as a durable option so site-specific URLs
-            // remain correct even when the transient expires or the API
-            // is temporarily unreachable.
+            // Persist site_id so site-specific URLs survive transient expiry or API downtime.
             if ( ! empty( $site_info['id'] ) ) {
                 update_option( 'flywp_site_id', (int) $site_info['id'], false );
             }


### PR DESCRIPTION
## Issue-Description:
The SMTP Configuration button on the Email tab redirected to `https://app.flywp.com/email` (404) instead of `https://app.flywp.com/site/{site_id}/email` when `site_info` was unavailable (API failure / expired transient).


## Fix-of-Issue:
In `includes/Admin.php` only:
- Persist `site_id` as a WordPress option when the API returns it successfully
- Use the stored option as fallback in `get_site_url()` when `$site_info is false`


## Impact:
- No view changes, no unrelated logic touched
- Safe fallback to `https://app.flywp.com` if `site_id` has never been stored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved site URL generation and storage to ensure consistent site identification and reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

----

Fixes: https://github.com/flywp/fly-helper/issues/21