### PR TITLE
ci: skip PHPCS step when a PR changes no PHP files

### DIFF
--- a/.github/workflows/wpcs.yml
+++ b/.github/workflows/wpcs.yml
@@ -37,6 +37,7 @@ jobs:
           echo "files=$FILES" >> $GITHUB_OUTPUT
       
       - name: Detect coding standard violations
+        if: steps.changes.outputs.files != ''
         run: |
           phpcs -i
           vendor/bin/phpcs ${{ steps.changes.outputs.files }} -q --report=checkstyle | cs2pr --graceful-warnings


### PR DESCRIPTION
## Problem

The `Inspections` workflow fails on PRs that change **no PHP files** (e.g. PR #18, which only edits `readme.txt`).

The `Detect coding standard violations` step builds a list of changed `.php` files and passes it to `phpcs`:

```sh
vendor/bin/phpcs ${{ steps.changes.outputs.files }} -q --report=checkstyle | cs2pr --graceful-warnings
```

When the PR touches no PHP files, `steps.changes.outputs.files` is empty, so `phpcs` runs with **no file arguments**. It then falls back to the `<file>.</file>` directive in `phpcs.xml` and scans the **entire repository**, failing on pre-existing violations that have nothing to do with the PR.

## Fix

Guard the step with `if: steps.changes.outputs.files != ''` so it is skipped when there are no PHP files to inspect.

## Impact

- PRs changing no PHP files (readme/asset-only) no longer fail spuriously.
- PRs that do change PHP files are unaffected — behaviour is identical.

Unblocks #18.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized PHP code standard inspection workflow to skip unnecessary checks when no PHP files have been modified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flywp/fly-helper/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->