### PR TITLE
fix: prevent clean_nav_menu crash on PHP 8.5 and reduce theme breakage

### DIFF
--- a/includes/Optimizations.php
+++ b/includes/Optimizations.php
@@ -72,7 +72,7 @@ class Optimizations {
                 'self_ping'      => true,
                 'comments'       => false,
                 'jquery_migrate' => true,
-                'clean_nav_menu' => true,
+                'clean_nav_menu' => false,
                 'rss_feed'       => false,
                 'xmlrpc'         => true,
             ],

--- a/includes/Optimizations/General.php
+++ b/includes/Optimizations/General.php
@@ -119,6 +119,10 @@ class General extends Base {
      */
     public function clean_nav_menu() {
         add_filter( 'nav_menu_css_class', function ( $classes ) {
+            if ( ! is_array( $classes ) ) {
+                return $classes;
+            }
+
             return array_intersect( $classes, [
                 'current-menu-item',
                 'menu-item-has-children',
@@ -126,8 +130,6 @@ class General extends Base {
                 'current-menu-ancestor',
             ] );
         } );
-
-        add_filter( 'nav_menu_item_id', '__return_null' );
     }
 
     /**


### PR DESCRIPTION
## Summary

The **Clean Navigation Menu** optimization (`includes/Optimizations/General.php`) caused two problems, both addressed here:

1. **Fatal crash on PHP 8.5** — the `nav_menu_css_class` callback called `array_intersect( $classes, [...] )` assuming `$classes` is always an array. Some page builders pass a *string*, which throws an uncaught `TypeError` on PHP 8.5+ and white-screens the entire frontend (HTTP 500).
2. **Theme/plugin breakage** — the feature allowlisted only 4 classes (stripping everything else) and removed all menu item IDs, breaking submenus, mega menus, JS targeting and accessibility on themes that rely on custom menu classes. It was also enabled by default.

## Changes

- **`General.php`** — add an `is_array()` guard to the `nav_menu_css_class` callback (returns the value unchanged when not an array); this matches the existing emoji guard at `General.php:48`.
- **`General.php`** — remove `add_filter( 'nav_menu_item_id', '__return_null' )` so menu item IDs are preserved.
- **`Optimizations.php`** — flip the `clean_nav_menu` default from `true` → `false`, making it opt-in. Existing sites keep their saved value (the settings save handler always writes every field; defaults only apply when no option row exists).

> Note: the class allowlist contents are unchanged — when a user explicitly enables the feature, it behaves as before, just crash-safe and without stripping IDs.

## Testing

- `php -l` passes on both files.
- String passed to `nav_menu_css_class` returns unchanged (no `TypeError`).
- Array input still trims to the allowlisted classes.
- Menu item IDs present in rendered markup.
- Fresh install resolves `clean_nav_menu` to `false`; previously-saved enabled sites stay enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation menu CSS class handling to properly validate input types before processing, ensuring more robust behavior.

* **Chores**
  * Updated default configuration settings for the navigation menu optimization feature to be disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->